### PR TITLE
gh #3 Update based on L2 HAL certification test coverage

### DIFF
--- a/include/plat_power.h
+++ b/include/plat_power.h
@@ -135,7 +135,7 @@ pmStatus_t PLAT_INIT( void );
 /**
  * @brief Sets the CPE Power State
  *
- * This fumction is just required to hold the value of the current power state status.
+ * This function is just required to hold the value of the current power state status.
  *
  * @param[in]  newState - The new power state value
  *
@@ -221,12 +221,11 @@ pmStatus_t PLAT_API_GetWakeupSrc( PWRMGR_WakeupSrcType_t srcType, bool  *enable 
 /**
  * @brief Resets the power state of the device
  * 
- * @note PLAT_Reset() will be deprecated.
+ * @note PLAT_Reset() is deprecated.
  *
  * @param[in] newState  - The state to be set
  * 
  * @return    pmStatus_t                - Status
- * @retval    PWRMGR_SUCCESS            - Success
  * @retval    PWRMGR_NOT_INITIALIZED    - Module is not initialised
  * @retval    PWRMGR_INVALID_ARGUMENT   - Parameter passed to this function is invalid
  * @retval    PWRMGR_SET_FAILURE        - Failed to update
@@ -234,6 +233,8 @@ pmStatus_t PLAT_API_GetWakeupSrc( PWRMGR_WakeupSrcType_t srcType, bool  *enable 
  * @pre PLAT_INIT() must be called before calling this API
  * 
  * @warning This API is Not thread safe
+ * 
+ * @note Given that PLAT_Reset() reboots the device, it does not return on a success
  *
  * @see PWRMgr_PowerState_t
  * 


### PR DESCRIPTION
Documentation updates as provided during the review feedback. Adding extra information and deprecating the no longer active APIs to be used is part of this review.